### PR TITLE
Update CWVR to v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 1.0.1
+
+**Time for more controllers!**
+
+The most important part of this update is control rebinding. Controllers with specialized layouts (like the HTC vive or WMR) we're not able to play CWVR. Now you can go into the settings and change the bindings to your needs.
+
+- Replaced the `Controls` menu in the settings with VR controls, that can be rebound at any time, whether you are in-game or not
+- Fixed the defibrillator not using VR controls as input
+- Fixed the quota and views UI not being visible
+
 # 1.0.0
 
 **Time to get SpöökFamous!!**

--- a/CWVR.csproj
+++ b/CWVR.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>CWVR</AssemblyName>
     <Description>Recording creatures in VR</Description>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <Title>ContentWarningVR</Title>
@@ -25,6 +25,7 @@
     <PackageReference Include="ContentWarning" Version="1.12.0" />
     <PackageReference Include="CW.Zorro" Version="1.8.0" />
     <PackageReference Include="HBAO.Universal" Version="1.9.0-cw" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="PhotonUnityNetworking" Version="1.9.0-cw" />
     <PackageReference Include="Unity.Animation.Rigging" Version="1.2.1" />
     <PackageReference Include="Unity.InputSystem" Version="1.7.0" />

--- a/Docs/Thunderstore/CONTROLS.md
+++ b/Docs/Thunderstore/CONTROLS.md
@@ -2,6 +2,8 @@
 
 For item swapping, press and hold the "Interact" button, and use "Zoom In" and "Zoom Out" to cycle through your inventory. Item swapping has been made this way as to not interfere with the camera zooming.
 
+### Default (Oculus & Index)
+
 | Action                   | Binding                   |
 |--------------------------|---------------------------|
 | Movement                 | Left Joystick             |
@@ -24,3 +26,5 @@ For item swapping, press and hold the "Interact" button, and use "Zoom In" and "
 | Pivot (Spectating)       | Left Joystick             |
 | Spectate Next Player     | Right Trigger Button      |
 | Spectate Previous Player | Left Trigger Button       |
+
+> Other built-in controller types coming later

--- a/Docs/Thunderstore/README.md
+++ b/Docs/Thunderstore/README.md
@@ -53,4 +53,6 @@ You can change the mod configuration from within the game itself. Just launch th
 
 # Controls
 
-At the moment, CW // VR only supports Oculus styled controller layouts (ABXY-based). For more detailed controls, check out the controls [wiki page](https://thunderstore.io/c/content-warning/p/DaXcess/CWVR/wiki) on Thunderstore. 
+By default, the game only supports Oculus and Index controllers. If you are using any other type of controller, you can change the bindings in the `Controls` settings menu in the game settings.
+
+For a list of default controls, check out the controls [wiki page](https://thunderstore.io/c/content-warning/p/DaXcess/CWVR/wiki/1966-controls/) on Thunderstore. 

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -69,5 +69,15 @@ namespace CWVR.Properties {
                 return ((byte[])(obj));
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Byte[].
+        /// </summary>
+        internal static byte[] controls {
+            get {
+                object obj = ResourceManager.GetObject("controls", resourceCulture);
+                return ((byte[])(obj));
+            }
+        }
     }
 }

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -121,4 +121,7 @@
   <data name="contentwarningvr" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\contentwarningvr;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="controls" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\controls.json;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
 </root>

--- a/Resources/controls.json
+++ b/Resources/controls.json
@@ -1,0 +1,104 @@
+{
+  "default": {
+    "Movement": {
+      "controller": 0,
+      "axis": 1,
+      "deadzone": 0
+    },
+    "Jump": {
+      "controller": 1,
+      "button": 6,
+      "deadzone": 0
+    },
+    "Sprint": {
+      "controller": 0,
+      "button": 11,
+      "deadzone": 0
+    },
+    "Crouch": {
+      "controller": 1,
+      "button": 11,
+      "deadzone": 0
+    },
+    "Interact": {
+      "controller": 1,
+      "button": 5,
+      "deadzone": 0
+    },
+    "Use": {
+      "controller": 1,
+      "button": 4,
+      "deadzone": 0
+    },
+    "Drop": {
+      "controller": 1,
+      "button": 8,
+      "deadzone": 0
+    },
+    "FlipCamera": {
+      "controller": 0,
+      "button": 5,
+      "deadzone": 0
+    },
+    "Menu": {
+      "controller": 0,
+      "button": 6,
+      "deadzone": 0
+    },
+    "ResetHeight": {
+      "controller": 0,
+      "button": 8,
+      "deadzone": 0
+    },
+    "ZoomIn": {
+      "controller": 1,
+      "button": 14,
+      "deadzone": 0.75
+    },
+    "ZoomOut": {
+      "controller": 1,
+      "button": 15,
+      "deadzone": 0.75
+    },
+    "TurnLeft": {
+      "controller": 1,
+      "button": 16,
+      "deadzone": 0.75
+    },
+    "TurnRight": {
+      "controller": 1,
+      "button": 17,
+      "deadzone": 0.75
+    },
+    "ModalLeft": {
+      "controller": 0,
+      "button": 16,
+      "deadzone": 0.75
+    },
+    "ModalRight": {
+      "controller": 0,
+      "button": 17,
+      "deadzone": 0.75
+    },
+    "ModalPress": {
+      "controller": 1,
+      "button": 6,
+      "deadzone": 0
+    },
+    "Pivot": {
+      "controller": 0,
+      "axis": 1,
+      "deadzone": 0
+    },
+    "SpectateNext": {
+      "controller": 1,
+      "button": 4,
+      "deadzone": 0
+    },
+    "SpectatePrevious": {
+      "controller": 0,
+      "button": 4,
+      "deadzone": 0
+    }
+  }
+}

--- a/Source/Assets/AssetManager.cs
+++ b/Source/Assets/AssetManager.cs
@@ -9,6 +9,10 @@ internal static class AssetManager
     public static GameObject Keyboard;
     public static GameObject CaptchaKeyboard;
     public static GameObject VRSettingsTab;
+    public static GameObject BooleanSettingCell;
+    public static GameObject EnumSettingCell;
+    public static GameObject SliderSettingCell;
+    public static GameObject ControlSettingCell;
     
     public static Material WhiteMat;
 
@@ -25,6 +29,10 @@ internal static class AssetManager
         Keyboard = assetBundle.LoadAsset<GameObject>("NonNativeKeyboard");
         CaptchaKeyboard = assetBundle.LoadAsset<GameObject>("CaptchaKeyboard");
         VRSettingsTab = assetBundle.LoadAsset<GameObject>("VRSettingsTab");
+        BooleanSettingCell = assetBundle.LoadAsset<GameObject>("BooleanSettingCell");
+        EnumSettingCell = assetBundle.LoadAsset<GameObject>("EnumSettingCell");
+        SliderSettingCell = assetBundle.LoadAsset<GameObject>("SliderSettingCell");
+        ControlSettingCell = assetBundle.LoadAsset<GameObject>("ControlSettingCell");
         
         WhiteMat = assetBundle.LoadAsset<Material>("White");
         

--- a/Source/Config.cs
+++ b/Source/Config.cs
@@ -35,11 +35,6 @@ public class Config(ConfigFile file)
     public ConfigEntry<bool> ToggleSprint { get; } = file.Bind("Input", "ToggleSprint", false,
         "Whether the sprint button should toggle sprint instead of having to hold it down.");
 
-    public ConfigEntry<float> ToggleSprintTimer { get; } = file.Bind("Input", "ToggleSprintTimer", 1f,
-        new ConfigDescription(
-            "The amount of seconds that you need to stand still for sprint to be toggled off automatically. Requires sprint toggle to be enabled.",
-            new AcceptableValueRange<float>(0, 10)));
-
     // Internal configuration
 
     public ConfigEntry<bool> FirstTimeLaunch { get; } = file.Bind("Internal", "FirstTimeLaunch", true,
@@ -47,6 +42,12 @@ public class Config(ConfigFile file)
 
     public ConfigEntry<string> OpenXRRuntimeFile { get; } = file.Bind("Internal", "OpenXRRuntimeFile", "",
         "Overrides the OpenXR plugin to use a specific json file. For internal use only.");
+
+    public ConfigEntry<bool> EnableCustomControls { get; } = file.Bind("Internal", "EnableCustomControls", false,
+        "Whether or not to use a customized control schema");
+
+    public ConfigEntry<string> CustomControls { get; } =
+        file.Bind("Internal", "CustomControls", "", "The custom control schema to use");
     
     public enum TurnProviderOption
     {

--- a/Source/Entrypoint.cs
+++ b/Source/Entrypoint.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using CWVR.Input;
 using CWVR.Patches;
 using CWVR.Player;
 using CWVR.UI;
@@ -35,10 +36,15 @@ internal static class UniversalEntrypoint
         if (__instance.name == "MainMenuGame")
         {
             // Create settings menu
-            Object.FindObjectOfType<MainMenuSettingsPage>(true).gameObject.AddComponent<UI.Settings.SettingsMenu>();
+            var settingsObj = Object.FindObjectOfType<MainMenuSettingsPage>(true).gameObject;
+            var remapHandler = settingsObj.AddComponent<RemapHandler>();
+            var settingsMenu = settingsObj.AddComponent<UI.Settings.SettingsMenu>();
+
+            settingsMenu.remapHandler = remapHandler;
+            
             return;
         }
-        
+
         __instance.StartCoroutine(Start());
     }
 

--- a/Source/Input/ControlScheme.cs
+++ b/Source/Input/ControlScheme.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+using UnityEngine.XR.Interaction.Toolkit;
+using XRController = CWVR.Input.InputSystem.XRController;
+
+namespace CWVR.Input;
+
+public static class ControlScheme
+{
+    private static readonly Dictionary<string, Dictionary<string, Binding>> BuiltInControls =
+        JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, Binding>>>(
+            Encoding.UTF8.GetString(Properties.Resources.controls));
+    
+    private static Dictionary<string, Binding> currentScheme = [];
+
+    public static IReadOnlyDictionary<string, Binding> Scheme => currentScheme;
+
+    static ControlScheme()
+    {
+        // Make sure the default profile is loaded, well..., by default
+        LoadProfile("default");
+    }
+
+    /// <summary>
+    /// Get the bindings for a specified built-in profile
+    /// </summary>
+    public static Dictionary<string, Binding> GetProfile(string name)
+    {
+        return BuiltInControls[name];
+    }
+    
+    /// <summary>
+    /// Loads a specified built in controller profile
+    /// </summary>
+    public static void LoadProfile(string name)
+    {
+        currentScheme = new Dictionary<string, Binding>(BuiltInControls[name]);
+    }
+
+    /// <summary>
+    /// Load a control schema from JSON
+    /// </summary>
+    public static void LoadSchema(string json)
+    {
+        currentScheme = JsonConvert.DeserializeObject<Dictionary<string, Binding>>(json);
+    }
+
+    /// <summary>
+    /// Update a binding within the current schema
+    /// </summary>
+    public static void UpdateBinding(string name, Binding binding)
+    {
+        currentScheme[name] = binding;
+    }
+
+    /// <summary>
+    /// Serialize the current control scheme as JSON
+    /// </summary>
+    public static string ToJson()
+    {
+        return JsonConvert.SerializeObject(currentScheme);
+    }
+}
+
+public struct Binding
+{
+    public XRController controller;
+    public InputHelpers.Button? button;
+    public InputHelpers.Axis2D? axis;
+
+    public float deadzone;
+
+    public static Dictionary<string, Binding> LoadFromJson(string json)
+    {
+        return JsonConvert.DeserializeObject<Dictionary<string, Binding>>(json);
+    }
+}

--- a/Source/Input/RemapHandler.cs
+++ b/Source/Input/RemapHandler.cs
@@ -1,0 +1,127 @@
+using System;
+using UnityEngine;
+using UnityEngine.XR.Interaction.Toolkit;
+
+namespace CWVR.Input;
+
+public class RemapHandler : MonoBehaviour
+{
+    private RemapListenHandle currentListenHandle;
+
+    public RemapListenHandle DetectBooleanControl(Action<Binding> onBindingSet)
+    {
+        currentListenHandle = new RemapListenHandle(onBindingSet, BindingType.BooleanControl);
+        return currentListenHandle;
+    }
+
+    public RemapListenHandle DetectAxis2DControl(Action<Binding> onBindingSet)
+    {
+        currentListenHandle = new RemapListenHandle(onBindingSet, BindingType.Axis2D);
+        return currentListenHandle;
+    }
+
+    private void Update()
+    {
+        if (currentListenHandle is null)
+            return;
+
+        switch (currentListenHandle.BindingType)
+        {
+            case BindingType.BooleanControl:
+                if (DetectButtonControl() is { } buttonBinding)
+                {
+                    currentListenHandle.OnBindingSet(buttonBinding);
+                    currentListenHandle = null;
+                }
+
+                break;
+
+            case BindingType.Axis2D:
+                if (DetectAxis2DControl(0.75f) is { } axisBinding)
+                {
+                    currentListenHandle.OnBindingSet(axisBinding);
+                    currentListenHandle = null;
+                }
+
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
+    }
+
+    private static Binding? DetectButtonControl()
+    {
+        var controllers = (InputSystem.XRController[])Enum.GetValues(typeof(InputSystem.XRController));
+        var buttons = (InputHelpers.Button[])Enum.GetValues(typeof(InputHelpers.Button));
+
+        foreach (var controller in controllers)
+        foreach (var button in buttons)
+        {
+            if (button is InputHelpers.Button.PrimaryTouch or InputHelpers.Button.SecondaryTouch
+                or InputHelpers.Button.Primary2DAxisTouch or InputHelpers.Button.Secondary2DAxisTouch)
+                continue;
+
+            var device = controller.GetDevice();
+            if (!device.isValid)
+                continue;
+
+            device.IsPressed(button, out var value, 0.75f);
+
+            if (value)
+            {
+                return new Binding
+                {
+                    controller = controller,
+                    button = button
+                };
+            }
+        }
+
+        return null;
+    }
+
+    private static Binding? DetectAxis2DControl(float deadzone)
+    {
+        var controllers = (InputSystem.XRController[])Enum.GetValues(typeof(InputSystem.XRController));
+        var axes = (InputHelpers.Axis2D[])Enum.GetValues(typeof(InputHelpers.Axis2D));
+
+        foreach (var controller in controllers)
+        foreach (var axis in axes)
+        {
+            var device = controller.GetDevice();
+            if (!device.isValid)
+                continue;
+
+            device.TryReadAxis2DValue(axis, out var value);
+
+            if (Mathf.Abs(value.x) < deadzone)
+                value.x = 0;
+            if (Mathf.Abs(value.y) < deadzone)
+                value.y = 0;
+
+            if (value.x != 0 || value.y != 0)
+            {
+                return new Binding
+                {
+                    controller = controller,
+                    axis = axis
+                };
+            }
+        }
+
+        return null;
+    }
+}
+
+public class RemapListenHandle(Action<Binding> onBindingSet, BindingType type)
+{
+    public Action<Binding> OnBindingSet { get; } = onBindingSet;
+    public BindingType BindingType { get; }= type;
+}
+
+public enum BindingType
+{
+    BooleanControl,
+    Axis2D
+}

--- a/Source/Patches/Items/DefibPatches.cs
+++ b/Source/Patches/Items/DefibPatches.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using HarmonyLib;
+
+namespace CWVR.Patches.Items;
+
+[CWVRPatch(CWVRPatchTarget.Universal)]
+[HarmonyPatch]
+internal static class DefibPatches
+{
+    [HarmonyPatch(typeof(Defib), nameof(Defib.Update))]
+    [HarmonyDebug]
+    [HarmonyTranspiler]
+    private static IEnumerable<CodeInstruction> FixDefibControllerInput(IEnumerable<CodeInstruction> instructions)
+    {
+        return new CodeMatcher(instructions)
+            .MatchForward(false, [new CodeMatch(OpCodes.Ldc_I4_0)])
+            .RemoveInstructions(2)
+            .InsertAndAdvance([
+                new CodeInstruction(OpCodes.Ldsfld, AccessTools.Field(typeof(global::Player), nameof(global::Player.localPlayer))),
+                new CodeInstruction(OpCodes.Ldfld, AccessTools.Field(typeof(global::Player), nameof(global::Player.input))),
+                new CodeInstruction(OpCodes.Ldfld, AccessTools.Field(typeof(global::Player.PlayerInput), nameof(global::Player.PlayerInput.clickWasPressed)))
+            ])
+            .InstructionEnumeration();
+    }
+}

--- a/Source/Player/VRSession.cs
+++ b/Source/Player/VRSession.cs
@@ -53,7 +53,19 @@ public class VRSession : MonoBehaviour
         HUD = gameObject.AddComponent<HUD>();        
         
         // Add VR settings to pause menu
-        FindObjectOfType<EscapeMenuSettingsPage>(true).gameObject.AddComponent<UI.Settings.SettingsMenu>();
+        var settingsObj = FindObjectOfType<EscapeMenuSettingsPage>(true).gameObject;
+        var settingsMenu = settingsObj.AddComponent<UI.Settings.SettingsMenu>();
+        var remapHandler = settingsObj.AddComponent<RemapHandler>();
+
+        settingsMenu.remapHandler = remapHandler;
+        
+        // Load controller bindings
+        if (Plugin.Config.EnableCustomControls.Value)
+            ControlScheme.LoadSchema(Plugin.Config.CustomControls.Value);
+        else
+            ControlScheme.LoadProfile(InputSystem.DetectControllerProfile());
+        
+        Controls.ReloadBindings();
     }
 
     private void OnDestroy()

--- a/Source/Plugin.cs
+++ b/Source/Plugin.cs
@@ -23,7 +23,7 @@ public class Plugin : BaseUnityPlugin
 {
     private const string PLUGIN_GUID = "io.daxcess.cwvr";
     private const string PLUGIN_NAME = "CWVR";
-    private const string PLUGIN_VERSION = "1.0.0";
+    private const string PLUGIN_VERSION = "1.0.1";
     
     private const string BANNER = "                             ,--.,--.                         \n ,-----.,--.   ,--.         /  //  /     ,--.   ,--.,------.  \n'  .--./|  |   |  |        /  //  /       \\  `.'  / |  .--. ' \n|  |    |  |.'.|  |       /  //  /         \\     /  |  '--'.' \n'  '--'\\|   ,'.   |      /  //  /           \\   /   |  |\\  \\  \n `-----''--'   '--'     /  //  /             `-'    `--' '--' \n                       `--'`--'                               \n\n             ___________________________ \n            < Another VR mod by DaXcess >\n             --------------------------- \n                    \\   ^__^\n                     \\  (oo)\\_______\n                        (__)\\       )\\/\\\n                            ||----w |\n                            ||     ||\n";
 
@@ -65,7 +65,7 @@ public class Plugin : BaseUnityPlugin
         {
             Logger.LogDebug($"Loaded scene: {scene.name}");
         };
-
+        
         if (disableVr || !InitializeVR())
             return;
 

--- a/Source/UI/HUD.cs
+++ b/Source/UI/HUD.cs
@@ -99,6 +99,14 @@ public class HUD : MonoBehaviour
         health.localEulerAngles = Vector3.zero;
         health.localScale = Vector3.one * 2.5f;
         
+        // Days left & Views
+        var statusBar = uiSource.Find("NextStep/List/GameObject");
+        
+        statusBar.transform.SetParent(RightHandCanvas.transform, false);
+        statusBar.localPosition = new Vector3(250, 710, -215);
+        statusBar.localEulerAngles = new Vector3(0, 0, 270);
+        statusBar.localScale = Vector3.one * 2.5f;
+        
         // Hotbar
         var hotbar = uiSource.Find("Hotbar");
         
@@ -135,7 +143,7 @@ public class HUD : MonoBehaviour
         // Player Customizer (if applicable)
         FindObjectOfType<PlayerCustomizer>()?.gameObject.AddComponent<Customizer>();
         
-        ReplaceSettings(interactionUi, stamina, oxygen, health, hotbar);
+        ReplaceCurvedUISettings(interactionUi, stamina, oxygen, health, statusBar, hotbar);
         CreateUICamera();
     }
 
@@ -181,7 +189,10 @@ public class HUD : MonoBehaviour
         cameraData.cameraStack.Add(UICamera);
     }
 
-    private void ReplaceSettings(params Component[] sources)
+    /// <summary>
+    /// Replaces the curved UI settings on a list of objects so that they work properly in VR
+    /// </summary>
+    private void ReplaceCurvedUISettings(params Component[] sources)
     {
         foreach (var source in sources)
         {

--- a/Source/UI/Settings/RemapBinding.cs
+++ b/Source/UI/Settings/RemapBinding.cs
@@ -1,0 +1,90 @@
+using System.Globalization;
+using CWVR.Input;
+using CWVR.Player;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace CWVR.UI.Settings;
+
+public class RemapBinding : MonoBehaviour
+{
+    [SerializeField] internal TextMeshProUGUI settingTitle;
+    [SerializeField] internal string settingName;
+ 
+    private Button button;
+    private TextMeshProUGUI buttonText;
+    private TMP_InputField deadzoneInput;
+    private Slider deadzoneSlider;
+
+    private Binding binding;
+    
+    public bool isAxisOnly;
+
+    internal RemapHandler remapHandler;
+    
+    private void Awake()
+    {
+        button = GetComponentInChildren<Button>();
+        buttonText = button.GetComponentInChildren<TextMeshProUGUI>();
+        deadzoneInput = GetComponentInChildren<TMP_InputField>();
+        deadzoneSlider = GetComponentInChildren<Slider>();
+        
+        button.onClick.AddListener(() =>
+        {
+            buttonText.text = "[...]";
+            
+            if (isAxisOnly)
+            {
+                remapHandler.DetectAxis2DControl(binding =>
+                {
+                    binding.deadzone = this.binding.deadzone;
+                    
+                    SetBinding(binding);
+                    SaveBinding();
+                });
+            }
+            else
+            {
+                remapHandler.DetectBooleanControl(binding =>
+                {
+                    binding.deadzone = this.binding.deadzone;
+
+                    SetBinding(binding);
+                    SaveBinding();
+                });
+            }
+        });
+    }
+
+    public void SetBinding(Binding binding)
+    {
+        this.binding = binding;
+        
+        buttonText.text =
+            $"{binding.controller} {(binding.button.HasValue ? Utils.PascalToLongString(binding.button.ToString()) : Utils.PascalToLongString(binding.axis.ToString()))}";
+        
+        deadzoneInput.text = binding.deadzone.ToString(CultureInfo.InvariantCulture);
+        deadzoneSlider.value = binding.deadzone;
+    }
+
+    public void UpdateDeadzone(float deadzone)
+    {
+        var binding = this.binding;
+        binding.deadzone = Mathf.Clamp(deadzone, 0, 1);
+
+        SetBinding(binding);
+        SaveBinding();
+    }
+
+    private void SaveBinding()
+    {
+        ControlScheme.UpdateBinding(settingName, binding);
+
+        Plugin.Config.CustomControls.Value = ControlScheme.ToJson();
+        
+        // Reload controls if we're in game
+        if (VRSession.Instance is { } instance)
+            instance.Controls.ReloadBindings();
+    }
+}

--- a/Source/Utils.cs
+++ b/Source/Utils.cs
@@ -1,10 +1,13 @@
+using System;
 using System.IO;
 using System.Runtime.Serialization.Json;
 using System.Security.Cryptography;
 using System.Text;
+using CWVR.Input;
 using CWVR.Player;
 using UnityEngine;
 using UnityEngine.SpatialTracking;
+using UnityEngine.XR;
 
 namespace CWVR;
 
@@ -76,6 +79,16 @@ internal static class Utils
             return VRSession.InVR;
 
         return VRSession.Instance && VRSession.Instance.NetworkManager.InVR(player);
+    }
+    
+    public static InputDevice GetDevice(this InputSystem.XRController controller)
+    {
+        return controller switch
+        {
+            InputSystem.XRController.Left => InputDevices.GetDeviceAtXRNode(XRNode.LeftHand),
+            InputSystem.XRController.Right => InputDevices.GetDeviceAtXRNode(XRNode.RightHand),
+            _ => throw new ArgumentOutOfRangeException(nameof(controller), controller, null)
+        };
     }
 }
 


### PR DESCRIPTION
# 1.0.1

**Time for more controllers!**

The most important part of this update is control rebinding. Controllers with specialized layouts (like the HTC vive or WMR) we're not able to play CWVR. Now you can go into the settings and change the bindings to your needs.

- Replaced the `Controls` menu in the settings with VR controls, that can be rebound at any time, whether you are in-game or not
- Fixed the defibrillator not using VR controls as input
- Fixed the quota and views UI not being visible