### PR TITLE
Fixed scrolling to previous item

### DIFF
--- a/Source/Patches/PlayerItemsPatches.cs
+++ b/Source/Patches/PlayerItemsPatches.cs
@@ -45,7 +45,7 @@ internal static class PlayerItemsPatches
         {
             case < 0:
                 __instance.player.data.selectedItemSlot =
-                    (__instance.player.data.selectedItemSlot + 0 + TOTAL_SLOTS) % TOTAL_SLOTS;
+                    (__instance.player.data.selectedItemSlot - 1 + TOTAL_SLOTS) % TOTAL_SLOTS;
                 break;
 
             case > 0:


### PR DESCRIPTION
Updated the line that handles scrolling to the previous item by replacing `selectedItemSlot + 0 + TOTAL_SLOTS` with `selectedItemSlot - 1 + TOTAL_SLOTS`